### PR TITLE
Add exported targets line to CMakeLists

### DIFF
--- a/industrial_robot_status_controller/CMakeLists.txt
+++ b/industrial_robot_status_controller/CMakeLists.txt
@@ -25,6 +25,7 @@ include_directories(
   ${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} src/controller.cpp)
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 install(


### PR DESCRIPTION
Without this, I get a build error that industrial_msgs/RobotStatus.h can't be found.
